### PR TITLE
Customise things more for us - i.e TDTify it

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -168,7 +168,7 @@ Layout styles
 	position: absolute;
 	right: 0;
 	margin-right: 1em;
-	max-width: 275px;
+	max-width: 375px;
 }
 
 .footer

--- a/css/styles.css
+++ b/css/styles.css
@@ -64,6 +64,11 @@ th, td
 	border-bottom: 1px solid #ddd;
 }
 
+pre
+{
+	margin: 0em 0em;
+}
+
 a:link { color: royalblue; }
 a:visited { color: purple; }
 a:focus { color: black; }

--- a/graphexp.html
+++ b/graphexp.html
@@ -27,7 +27,6 @@
 
 	///////////////////////////////////////////////
 	function search_query(){
-		//if (typeof graph_viz.simulation!=='undefined') {graph_viz.simulation.stop(); console.log('Simulation stopped!');}
 		graphioGremlin.search_query();
 	}
 
@@ -84,10 +83,10 @@
 			<div class="nav container" id="graph_bar">
 				<div class="nav inputs_container_bottom">
 					<div class="nav input_unit_container">
-						<input type="checkbox" name="line-haul" id="line-haul" checked=true/>
+						<input type="checkbox" name="line-haul" id="line-haul" checked/>
 						<label class="nav input_label" for="line-haul">Line Hauls</label>
 						
-						<input type="checkbox" name="last-mile" id="last-mile" checked=true/>
+						<input type="checkbox" name="last-mile" id="last-mile" checked/>
 						<label class="nav input_label" for="last-mile">Last Miles</label>
 					</div>
 					<div class="nav input_unit_container">
@@ -95,7 +94,7 @@
 						<input type="number" id="nbLayers" min="1" max="128" onclick="set_nb_layers()">
 					</div>
 					<div class="nav input_unit_container">
-						<input type="checkbox" name="showAllocations" id="show-allocations" checked=false/>
+						<input type="checkbox" name="showAllocations" id="show-allocations"/>
 						<label class="nav input_label" for="showAllocations">Show Allocation Data</label>
 
 						<input type="checkbox" name="showName_box" id="showName" onclick="graphShapes.show_names()"/>
@@ -188,23 +187,20 @@
 	}
 
 	function display_properties_bar(prop_list,item,text){
+		prop_list = prop_list.sort()
 		var nav_bar = d3.select("#graphInfoBar");
 		nav_bar.select("#property_bar_"+item).remove();
 		var property_bar = nav_bar.append("div").attr("id","property_bar_"+item);
 		property_bar.append('text').text(text).style("font-weight","bold");
 		var property_label = property_bar.selectAll('input').append("ul")
 			.data(prop_list).enter().append("li").append("pre");
-			
-
-			
+				
 		property_label.append('input').attr('type','checkbox').attr('id',function (d) { return item+"_"+d; })
 			.attr('id_nb',function (d) { return prop_list.indexOf(d); })
 			//.attr('onchange',function(d){display_prop(d);});
 			.attr('onchange','display_prop(this)');
 
 		property_label.append('label').text(function (d) { return d; });
-		
-
 	}
 
 	function display_color_choice(prop_list,item,text){

--- a/graphexp.html
+++ b/graphexp.html
@@ -84,16 +84,19 @@
 			<div class="nav container" id="graph_bar">
 				<div class="nav inputs_container_bottom">
 					<div class="nav input_unit_container">
-						<label class="nav input_label" for="edge_filter">Traverse by edge:</label>
-						<input name="edge_filter" id="edge_filter" value="" />
+						<input type="checkbox" name="line-haul" id="line-haul" checked=true/>
+						<label class="nav input_label" for="line-haul">Line Hauls</label>
+						
+						<input type="checkbox" name="last-mile" id="last-mile" checked=true/>
+						<label class="nav input_label" for="last-mile">Last Miles</label>
 					</div>
 					<div class="nav input_unit_container">
-						<label class="nav input_label" for="nbLayers">Nb of layers</label>
+						<label class="nav input_label" for="nbLayers">Layers</label>
 						<input type="number" id="nbLayers" min="1" max="128" onclick="set_nb_layers()">
 					</div>
 					<div class="nav input_unit_container">
 						<input type="checkbox" name="Freeze" id="freeze-in" />
-						<label class="nav input_label" for="freeze-in">Freeze exploration</label>
+						<label class="nav input_label" for="freeze-in">Freeze</label>
 					</div>
 					<div class="nav input_unit_container">
 						<input type="checkbox" name="showName_box" id="showName" onclick="graphShapes.show_names()"/>

--- a/graphexp.html
+++ b/graphexp.html
@@ -74,7 +74,7 @@
 					</div>
 					<div class="nav input_unit_container">
 						<label for="limit_field">Results limit:</label>
-						<input name="limit_field" id="limit_field" value="50" min="1" max="1000" type="number"/>
+						<input name="limit_field" id="limit_field" value="10" min="1" max="1000" type="number"/>
 					</div>
 				</div>
 				<div class="nav controls">

--- a/graphexp.html
+++ b/graphexp.html
@@ -95,7 +95,7 @@
 						<input type="number" id="nbLayers" min="1" max="128" onclick="set_nb_layers()">
 					</div>
 					<div class="nav input_unit_container">
-						<input type="checkbox" name="showAllocations" id="show-allocations" checked=true/>
+						<input type="checkbox" name="showAllocations" id="show-allocations" checked=false/>
 						<label class="nav input_label" for="showAllocations">Show Allocation Data</label>
 
 						<input type="checkbox" name="showName_box" id="showName" onclick="graphShapes.show_names()"/>
@@ -192,10 +192,9 @@
 		nav_bar.select("#property_bar_"+item).remove();
 		var property_bar = nav_bar.append("div").attr("id","property_bar_"+item);
 		property_bar.append('text').text(text).style("font-weight","bold");
-		//d3.select('#property_bar').append('text').text('hello')
 		var property_label = property_bar.selectAll('input').append("ul")
-			.data(prop_list).enter().append("li");
-			//.append('label');
+			.data(prop_list).enter().append("li").append("pre");
+			
 
 			
 		property_label.append('input').attr('type','checkbox').attr('id',function (d) { return item+"_"+d; })
@@ -304,7 +303,6 @@
 			return "";
 		}
 	}
-
 
 	function set_nb_layers(){
 		var nb_layers = parseInt(document.getElementById('nbLayers').value);

--- a/graphexp.html
+++ b/graphexp.html
@@ -95,12 +95,15 @@
 						<input type="number" id="nbLayers" min="1" max="128" onclick="set_nb_layers()">
 					</div>
 					<div class="nav input_unit_container">
-						<input type="checkbox" name="Freeze" id="freeze-in" />
-						<label class="nav input_label" for="freeze-in">Freeze</label>
-					</div>
-					<div class="nav input_unit_container">
+						<input type="checkbox" name="showAllocations" id="show-allocations" checked=true/>
+						<label class="nav input_label" for="showAllocations">Show Allocation Data</label>
+
 						<input type="checkbox" name="showName_box" id="showName" onclick="graphShapes.show_names()"/>
 						<label class="nav input_label" for="showName">Show labels</label>
+					</div>
+					<div class="nav input_unit_container">
+						<input type="checkbox" name="Freeze" id="freeze-in" />
+						<label class="nav input_label" for="freeze-in">Freeze</label>
 					</div>
 				</div>
 				<div class="nav controls">
@@ -308,7 +311,6 @@
 		//var nb_layers = parseInt(layer_input.getAttribute("value"));
 		console.log(nb_layers)
 		graph_viz.layers.set_nb_layers(nb_layers);
-
 	}
 
 	function show_hide_element(element_label){

--- a/scripts/graphConf.js
+++ b/scripts/graphConf.js
@@ -17,7 +17,7 @@ const REST_TIMEOUT = 120000
 
 // Graph configuration
 const default_nb_of_layers = 3;
-const node_limit_per_request = 50;
+const node_limit_per_request = 10;
 
 // Simulation
 const force_strength = -600;
@@ -48,4 +48,4 @@ const use_curved_edges = true;
 
 // The number of vertices and edges randomly grabbed used to define the graph schema. 
 // Higher number means slower graph retreival but more info
-const graphDefinedBy = 10
+const graphDefinedBy = 5

--- a/scripts/graphConf.js
+++ b/scripts/graphConf.js
@@ -16,7 +16,7 @@ const REST_TIMEOUT = 120000
 
 
 // Graph configuration
-const default_nb_of_layers = 3;
+const default_nb_of_layers = 5;
 const node_limit_per_request = 10;
 
 // Simulation

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -46,9 +46,6 @@ var graphioGremlin = (function(){
 				}
 			}
 			var returnQuery = query.trim();
-//                        if(returnQuery.endsWith(".toList();")){
-//                            returnQuery = returnQuery+".toList();";
-//                        }
 			return returnQuery;
 		}
 

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -285,7 +285,7 @@ var graphioGremlin = (function(){
 		}
 	
 		data = graphson3to1(data);
-		
+
 		if (!(0 in data)) {
 			message = 'No data. Check the communication protocol. (Try changing Gremlin version to 3.3.*).'
 			console.log(message)

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -206,12 +206,7 @@ var graphioGremlin = (function(){
 			if (COMMUNICATION_PROTOCOL == 'REST'){
 				let server_url = "http://"+host+":"+port;
 				run_ajax_request(gremlin_query,server_url,query_type,active_node,message,callback);
-			}
-			else if (COMMUNICATION_PROTOCOL == 'websocket'){
-				let server_url = "ws://"+host+":"+port+"/gremlin"
-				run_websocket_request(gremlin_query,server_url,query_type,active_node,message,callback);
-			}
-			else {
+			} else {
 				console.log('Bad communication protocol. Check configuration file. Accept "REST" or "websocket" .')
 			}
 				
@@ -277,81 +272,6 @@ var graphioGremlin = (function(){
 				$('#messageArea').html('');
 			}
 		});
-	}
-
-	//////////////////////////////////////////////////////////////////////////////////////////////////////
-	// Websocket connection
-	/////////////////////////////////////////////////////////////////////////////////////////////////////
-	function run_websocket_request(gremlin_query,server_url,query_type,active_node,message,callback){
-		$('#messageArea').html('<h3>(loading)</h3>');
-
-		var msg = { "requestId": uuidv4(),
-			"op":"eval",
-			"processor":"",
-			"args":{"gremlin": gremlin_query,
-				"bindings":{},
-				"language":"gremlin-groovy"}}
-
-		var data = JSON.stringify(msg);
-
-		var ws = new WebSocket(server_url);
-		ws.onopen = function (event){
-			ws.send(data,{ mask: true});	
-		};
-		ws.onerror = function (err){
-			console.log('Connection error using websocket');
-			console.log(err);
-			if (query_type == 'editGraph'){
-				$('#outputArea').html("<p> Connection error using websocket</p>"
-					+"<p> Problem accessing "+server_url+ " </p>"+
-					"<p> Possible cause: creating a edge with bad node ids "+
-					"(linking nodes not existing in the DB). </p>");
-				$('#messageArea').html('');
-			} else {$('#outputArea').html("<p> Connection error using websocket</p>"
-					+"<p> Cannot connect to "+server_url+ " </p>");
-				$('#messageArea').html('');
-			}
-
-		};
-		ws.onmessage = function (event){
-			var response = JSON.parse(event.data);
-			var code=Number(response.status.code)
-			if(!isInt(code) || code<200 || code>299) {
-				$('#outputArea').html(response.status.message);
-				$('#messageArea').html("Error retrieving data");
-				return 1;
-			}
-			var data = response.result.data;
-			if (data == null){
-				if (query_type == 'editGraph'){
-					$('#outputArea').html(response.status.message);
-					$('#messageArea').html('Could not write data to DB.' +
-						"<p> Possible cause: creating a edge with bad node ids "+
-						"(linking nodes not existing in the DB). </p>");
-					return 1;
-				} else {
-					//$('#outputArea').html(response.status.message);
-					//$('#messageArea').html('Server error. No data.');
-					//return 1;
-				}
-			}
-			//console.log(data)
-			//console.log("Results received")
-			if(callback){
-				callback(data);
-			} else {
-				handle_server_answer(data,query_type,active_node,message);
-			}
-		};		
-	}
-
-	// Generate uuid for websocket requestId. Code found here:
-	// https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-	function uuidv4() {
-	  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-		var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-		return v.toString(16);
-	  });
 	}
 
 	//////////////////////////////////////////////////////////////////////////////////////////////////

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -283,17 +283,9 @@ var graphioGremlin = (function(){
 			$('#messageArea').html('');
 			return // TODO handle answer to check if data has been written
 		}
-		//console.log(COMMUNICATION_METHOD)
-		if (COMMUNICATION_METHOD == 'GraphSON3'){
-			//console.log(data)
-			data = graphson3to1(data);
-			var arrange_data = arrange_datav3;
-		} else {
-			console.log('Bad communication protocol. Accept "GraphSON2" or "GraphSON3".'
-				+' Using default GraphSON3.')
-			data = graphson3to1(data);
-			var arrange_data = arrange_datav3;
-		}
+	
+		data = graphson3to1(data);
+		
 		if (!(0 in data)) {
 			message = 'No data. Check the communication protocol. (Try changing Gremlin version to 3.3.*).'
 			console.log(message)
@@ -311,7 +303,7 @@ var graphioGremlin = (function(){
 			display_color_choice(_node_properties,'nodes','Node color by:');
 		} else {
 			//console.log(data);
-			var graph = arrange_data(data);
+			var graph = arrange_datav3(data);
 			//console.log(graph)
 			if (query_type=='click') var center_f = 0; //center_f=0 mean no attraction to the center for the nodes 
 			else if (query_type=='search') var center_f = 1;

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -164,17 +164,31 @@ var graphioGremlin = (function(){
 			 !isNaN(parseInt(value, 10));
 	}
 
+	function getTraversableEdges(){
+		var edgesToTraverse = "";
+		var isLastMileChecked = $('#last-mile')[0].checked;
+		var isLineHaulChecked = $('#line-haul')[0].checked;
+
+		if(isLastMileChecked && isLineHaulChecked){
+			edgesToTraverse = "'LineHaul','LastMile'"
+		} else if(isLastMileChecked){
+			edgesToTraverse = "'LastMile'"
+		} else if(isLineHaulChecked){
+			edgesToTraverse = "'LineHaul'"
+		} else {
+			edgesToTraverse = "'NoEdgesToTravese'" //Hack to make sure no edges returned when both check boxes are unticked
+		}
+		
+		return edgesToTraverse
+	}
+
 	function click_query(d) {
-		var edge_filter = $('#edge_filter').val();
-		// Gremlin query
-		// var gremlin_query = traversal_source + ".V("+d.id+").bothE().bothV().path()"
-		//'inject' is necessary in case of an isolated node ('both' would lead to an empty answer)
 		var id = d.id;
 		if(isNaN(id)){ // Add quotes if id is a string (not a number).
 			id = '"'+id+'"';
 		}
 		
-		var raw_query = traversal_source + ".V(" + id + ").as('v1').bothE().as('e').bothV().as('v2').where(neq('v1'))" + getLimitedGremlinQuery() + ".path()"
+		var raw_query = traversal_source + ".V(" + id + ").as('v1').bothE(" + getTraversableEdges() + ").as('e').bothV().as('v2').where(neq('v1'))" + getLimitedGremlinQuery() + ".path()"
 		var gremlin_query_nodes = "nodes = " + raw_query + ".select('v1', 'v2').select(values).unfold()"
 		var gremlin_query_edges = "edges = " + raw_query + ".select('e')"
 		var gremlin_query = gremlin_query_nodes+'\n'+gremlin_query_edges+'\n'+'[nodes.toList(),edges.toList()]'

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -323,8 +323,6 @@ var graphioGremlin = (function(){
 		$('#messageArea').html('');
 	}
 
-
-
 	//////////////////////////////////////////////////////////////////////////////////////////////////
 	function make_properties_list(data){
 		var prop_dic = {};
@@ -400,7 +398,30 @@ var graphioGremlin = (function(){
 		return data_dic
 	}
 
-	function extract_infov3(data) {
+	/**
+	 * This is used to check if a string is json. We need this to make sure we display certain fields correctly
+	 * 
+	 * @param {String} item The thing we suspect might be json.
+	 */
+	function isJson(item) {
+    item = typeof item !== "string"
+        ? JSON.stringify(item)
+        : item;
+
+    try {
+        item = JSON.parse(item);
+    } catch (e) {
+        return false;
+    }
+
+    if (typeof item === "object" && item !== null) {
+        return true;
+    }
+
+    return false;
+}
+
+function extract_infov3(data) {
 	var data_dic = {id:data.id, label:data.label, type:data.type, properties:{}}
 	var prop_dic = data.properties
 	//console.log(prop_dic)
@@ -411,6 +432,10 @@ var graphioGremlin = (function(){
 				property['summary'] = get_vertex_prop_in_list(prop_dic[key]).toString();
 			} else {
 				var property = prop_dic[key]['value'];
+				//Improve Formatting
+				if(isJson(property)){
+					property = JSON.stringify(JSON.parse(property), undefined, 2)
+				}
 			}
 			//property = property.toString();
 			data_dic.properties[key] = property;

--- a/scripts/infobox.js
+++ b/scripts/infobox.js
@@ -117,6 +117,18 @@ var infobox = (function(){
 	  	append_keysvalues(info_table,data_dic)
 	}
 
+	/**
+	 * Helper methods which sorts a dictionary into an array order by it's keys
+	 * 
+	 * @param {Dictionary} dict 
+	 */
+	function getSortedKeys(dict){
+		var sorted = [];
+		for(var key in dict) {
+			sorted[sorted.length] = key;
+		}
+		return sorted.sort();
+	}
 
 	function _display_DBinfo(d){
 		_table_DBinfo.select("tbody").remove();
@@ -127,7 +139,9 @@ var infobox = (function(){
 		 	}
 		}
 		else {
-		 	for (var key in d.properties){
+			var sortedKeys = getSortedKeys(d.properties)
+		 	for (var index in sortedKeys){
+				var key = sortedKeys[index]
 				var render = true;
 
 				if(key == "allocationData" && !$('#show-allocations')[0].checked){

--- a/scripts/infobox.js
+++ b/scripts/infobox.js
@@ -128,9 +128,17 @@ var infobox = (function(){
 		}
 		else {
 		 	for (var key in d.properties){
-		 		var new_info_row = info_table.append("tr");
-	 			new_info_row.append("td").append("pre").text(key);
-	 			new_info_row.append("td").append("pre").text(d.properties[key]);
+				var render = true;
+
+				if(key == "allocationData" && !$('#show-allocations')[0].checked){
+					render = false
+				}
+
+				if(render){
+					var new_info_row = info_table.append("tr");
+					new_info_row.append("td").append("pre").text(key);
+					new_info_row.append("td").append("pre").text(d.properties[key]);
+				}
 			}
 		}
 	}

--- a/scripts/infobox.js
+++ b/scripts/infobox.js
@@ -39,7 +39,7 @@ var infobox = (function(){
 		_table_IDinfo = graphElem_bar.append("table").attr("id","tableIdDetails");
 		init_table(_table_IDinfo,["Key","Value"]);
 		_table_DBinfo = graphElem_bar.append("table").attr("id","tableDBDetails");
-		init_table(_table_DBinfo,["Key","Value","Property"]);
+		init_table(_table_DBinfo,["Key","Value"]);
 		hide_element(label_graph);
 
 	}
@@ -77,8 +77,8 @@ var infobox = (function(){
 	function append_keysvalues(table_body,data,type){
 		for (var key in data){
 			var info_row = table_body.append("tr");
-	 		var key_text = info_row.append("td").text(key).style("font-size",_font_size);
-	 		var value_text = info_row.append("td").text(data[key]).style("font-size",_font_size);
+	 		var key_text = info_row.append("td").append("pre").text(key).style("font-size",_font_size);
+	 		var value_text = info_row.append("td").append("pre").text(data[key]).style("font-size",_font_size);
 	 		if (type=="bold") {
 	 			key_text.style('font-weight','bolder');}
 		}
@@ -129,9 +129,8 @@ var infobox = (function(){
 		else {
 		 	for (var key in d.properties){
 		 		var new_info_row = info_table.append("tr");
-	 			new_info_row.append("td").text(key);
-	 			new_info_row.append("td").text(d.properties[key]);
-	 			new_info_row.append("td").text("")
+	 			new_info_row.append("td").append("pre").text(key);
+	 			new_info_row.append("td").append("pre").text(d.properties[key]);
 			}
 		}
 	}
@@ -145,15 +144,15 @@ var infobox = (function(){
  			if ( ((typeof value[subkey] === "object") && (value[subkey] !== null)) && ('properties' in value[subkey]) ){
  				for (var subsubkey in value[subkey].properties){
  					var new_info_row = info_table.append("tr");
- 					new_info_row.append("td").text(key).style("font-size",_font_size);
- 					new_info_row.append("td").text(value[subkey].value).style("font-size",_font_size);
- 					new_info_row.append("td").text(subsubkey + ' : '+ value[subkey].properties[subsubkey]).style("font-size",_font_size);
+ 					new_info_row.append("td").append("pre").text(key).style("font-size",_font_size);
+ 					new_info_row.append("td").append("pre").text(value[subkey].value).style("font-size",_font_size);
+ 					new_info_row.append("td").append("pre").text(subsubkey + ' : '+ value[subkey].properties[subsubkey]).style("font-size",_font_size);
  				}
  			} else {
  				var new_info_row = info_table.append("tr");
- 				new_info_row.append("td").text(key).style("font-size",_font_size);
- 				new_info_row.append("td").text(value[subkey].value).style("font-size",_font_size);
- 				new_info_row.append("td").text('').style("font-size",_font_size);
+ 				new_info_row.append("td").append("pre").text(key).style("font-size",_font_size);
+ 				new_info_row.append("td").append("pre").text(value[subkey].value).style("font-size",_font_size);
+ 				new_info_row.append("td").append("pre").text('').style("font-size",_font_size);
  			}
 		}
 	}


### PR DESCRIPTION
So this does a bunch of things:

1. Get's rid of web socket protocol - we don't need it, we use REST
2. Optimises the traversal to get a nodes edges and their properties. It's now one traversals rather than 2
3. Limit the number of edges to explore/expand based on the number in the search box.
4. Make it optional to display the `allocationData` it created a lot of noise so I made it an optional rendering defaulting to false
5. Filter the types of edges traversed. Rather than traverse ALL edges ALL the time you can limit to the edge type. I.e Line Haul/Last Mile/Both
6. Make allocation data rendering pretty/readable, i.e. it's not a blob of text anymore
7. Order all properties alphabetically. I.e. no more property jumbling as you click around. 